### PR TITLE
feat: Add GitHub Action for code coverage reporting

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:
@@ -35,5 +36,22 @@ jobs:
         poetry install
     - name: Test with pytest
       run: |
-        poetry run pytest
-  
+        poetry run pytest --cov=src --cov-report=xml:coverage.xml
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage.xml
+    - name: Publish Coverage Check
+      uses: MADLAD/publish-coverage-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        coverage_file: coverage.xml
+        coverage_type: cobertura # pytest-cov's XML format is cobertura
+        comment_title: 'Code Coverage Report'
+        min_coverage_overall: 0 # We don't want to fail the check based on overall coverage
+        min_coverage_new: 0 # We don't want to fail based on new code coverage
+        # The following are important for reporting changes
+        comment_on_changed_files: true
+        # Ensure this action has permissions to write to PRs.
+        # The main workflow permissions might need `pull-requests: write`.

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,7 @@ jobs:
         name: coverage-report
         path: coverage.xml
     - name: Publish Coverage Check
-      uses: MADLAD/publish-coverage-check@v1
+      uses: MADLAD/publish-coverage-check@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         coverage_file: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ black = ">=25.1.0,<26.0.0"
 autopep8 = ">=2.3.2,<3.0.0"
 pre-commit = "^4.2.0"
 flake8 = "^7.2.0"
+pytest-cov = "^2.12"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
This commit introduces a GitHub Action workflow to measure code coverage and provide insights on Pull Requests.

Key changes:
- Added `pytest-cov` to development dependencies for generating coverage data.
- Updated the `python-app.yml` workflow:
  - Modified the pytest execution to collect coverage information for the `src` directory and output it in XML (cobertura) format.
  - Added a step to upload the `coverage.xml` report as a workflow artifact for inspection.
  - Integrated the `MADLAD/publish-coverage-check` action to:
    - Post a comment on Pull Requests detailing the code coverage.
    - Highlight changes in coverage for existing code.
    - Report the coverage percentage for new code introduced in the PR.
- Granted `pull-requests: write` permission to the workflow to allow commenting.

This setup aims to provide developers with timely feedback on how their changes impact code coverage, without enforcing strict coverage gates.