### PR TITLE
feat: Add data models for sample mapping

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,22 @@
+# src/models/__init__.py
+
+from .sample_model import SampleModel
+from .sample_mapping_item_model import SampleMappingItemModel
+from .sample_mapping_model import SampleMappingModel
+
+# It's good practice to also import other models if they exist,
+# but based on the previous ls output and the current task,
+# we are focusing on the sample-related models.
+# For example:
+# from .project_model import ProjectModel
+# from .recording_model import RecordingModel
+
+__all__ = [
+    'SampleModel',
+    'SampleMappingItemModel',
+    'SampleMappingModel',
+    # If other models like ProjectModel were imported above,
+    # they should also be added here.
+    # 'ProjectModel',
+    # 'RecordingModel',
+]

--- a/src/models/sample_mapping_item_model.py
+++ b/src/models/sample_mapping_item_model.py
@@ -1,3 +1,74 @@
-# Placeholder for sample_mapping_item_model.py
+# src/models/sample_mapping_item_model.py
+
+from .sample_model import SampleModel
+
 class SampleMappingItemModel:
-    pass
+    """
+    Represents a single mapping rule for a sample, linking it to MIDI
+    note ranges, velocity layers, and other performance parameters.
+    """
+    def __init__(self,
+                 sample: SampleModel,
+                 note_start: int = 0,
+                 note_end: int = 127,
+                 velocity_start: int = 0,
+                 velocity_end: int = 127,
+                 round_robin_group: int = 0,
+                 tune_cents: float = 0.0,
+                 pan: float = 0.0):
+        """
+        Initializes a SampleMappingItemModel instance.
+
+        Args:
+            sample (SampleModel): The sample associated with this mapping.
+            note_start (int): MIDI note number for the start of the key range (0-127). Defaults to 0.
+            note_end (int): MIDI note number for the end of the key range (0-127). Defaults to 127.
+            velocity_start (int): MIDI velocity for the start of the velocity range (0-127). Defaults to 0.
+            velocity_end (int): MIDI velocity for the end of the velocity range (0-127). Defaults to 127.
+            round_robin_group (int, optional): The round-robin group identifier. Defaults to 0.
+            tune_cents (float, optional): Fine-tuning in cents. Defaults to 0.0.
+            pan (float, optional): Stereo pan (-1.0 for left, 1.0 for right). Defaults to 0.0.
+        """
+        if not isinstance(sample, SampleModel):
+            raise TypeError("sample must be an instance of SampleModel.")
+
+        if not (isinstance(note_start, int) and 0 <= note_start <= 127):
+            raise ValueError("note_start must be an integer between 0 and 127.")
+        if not (isinstance(note_end, int) and 0 <= note_end <= 127):
+            raise ValueError("note_end must be an integer between 0 and 127.")
+        if note_start > note_end:
+            raise ValueError("note_start cannot be greater than note_end.")
+
+        if not (isinstance(velocity_start, int) and 0 <= velocity_start <= 127):
+            raise ValueError("velocity_start must be an integer between 0 and 127.")
+        if not (isinstance(velocity_end, int) and 0 <= velocity_end <= 127):
+            raise ValueError("velocity_end must be an integer between 0 and 127.")
+        if velocity_start > velocity_end:
+            raise ValueError("velocity_start cannot be greater than velocity_end.")
+
+        if not isinstance(round_robin_group, int):
+            raise TypeError("round_robin_group must be an integer.")
+
+        if not isinstance(tune_cents, (int, float)):
+            raise TypeError("tune_cents must be a number (int or float).")
+
+        if not isinstance(pan, (int, float)):
+            raise TypeError("pan must be a number (int or float).")
+        if not (-1.0 <= pan <= 1.0):
+            raise ValueError("pan must be a float between -1.0 and 1.0.")
+
+        self.sample: SampleModel = sample
+        self.note_start: int = note_start
+        self.note_end: int = note_end
+        self.velocity_start: int = velocity_start
+        self.velocity_end: int = velocity_end
+        self.round_robin_group: int = round_robin_group
+        self.tune_cents: float = float(tune_cents)
+        self.pan: float = float(pan)
+
+    def __repr__(self):
+        return (f"SampleMappingItemModel(sample={self.sample!r}, "
+                f"note_start={self.note_start}, note_end={self.note_end}, "
+                f"velocity_start={self.velocity_start}, velocity_end={self.velocity_end}, "
+                f"round_robin_group={self.round_robin_group}, "
+                f"tune_cents={self.tune_cents}, pan={self.pan})")

--- a/src/models/sample_mapping_model.py
+++ b/src/models/sample_mapping_model.py
@@ -1,0 +1,55 @@
+# src/models/sample_mapping_model.py
+
+from typing import List
+from .sample_mapping_item_model import SampleMappingItemModel
+
+class SampleMappingModel:
+    """
+    Represents a collection of sample mapping items, defining how multiple
+    samples are mapped to MIDI events for an instrument.
+    """
+    def __init__(self):
+        """
+        Initializes a SampleMappingModel instance with an empty list of mapping items.
+        """
+        self.mapping_items: List[SampleMappingItemModel] = []
+
+    def add_mapping_item(self, item: SampleMappingItemModel):
+        """
+        Adds a SampleMappingItemModel to the collection.
+
+        Args:
+            item (SampleMappingItemModel): The mapping item to add.
+
+        Raises:
+            TypeError: If the item is not an instance of SampleMappingItemModel.
+        """
+        if not isinstance(item, SampleMappingItemModel):
+            raise TypeError("Only SampleMappingItemModel instances can be added.")
+        self.mapping_items.append(item)
+
+    def remove_mapping_item(self, item: SampleMappingItemModel):
+        """
+        Removes a SampleMappingItemModel from the collection.
+
+        Args:
+            item (SampleMappingItemModel): The mapping item to remove.
+
+        Raises:
+            ValueError: If the item is not found in the list.
+        """
+        try:
+            self.mapping_items.remove(item)
+        except ValueError:
+            raise ValueError("Item not found in mapping_items list.")
+
+    def __repr__(self):
+        return f"SampleMappingModel(mapping_items_count={len(self.mapping_items)})"
+
+    def __len__(self):
+        """Returns the number of mapping items."""
+        return len(self.mapping_items)
+
+    def __iter__(self):
+        """Allows iteration over the mapping items."""
+        return iter(self.mapping_items)

--- a/src/models/sample_model.py
+++ b/src/models/sample_model.py
@@ -1,3 +1,27 @@
-# Placeholder for sample_model.py
+# src/models/sample_model.py
+
 class SampleModel:
-    pass
+    """
+    Represents an individual audio sample file.
+    """
+    def __init__(self, file_path: str, root_note: int = None):
+        """
+        Initializes a SampleModel instance.
+
+        Args:
+            file_path (str): The path to the audio sample file.
+            root_note (int, optional): The MIDI root note of the sample.
+                                       Defaults to None if the sample is not pitched
+                                       or its pitch is to be determined by mapping.
+        """
+        if not isinstance(file_path, str) or not file_path:
+            raise ValueError("file_path must be a non-empty string.")
+
+        if root_note is not None and not (isinstance(root_note, int) and 0 <= root_note <= 127):
+            raise ValueError("root_note must be an integer between 0 and 127, or None.")
+
+        self.file_path: str = file_path
+        self.root_note: int = root_note
+
+    def __repr__(self):
+        return f"SampleModel(file_path='{self.file_path}', root_note={self.root_note})"

--- a/tests/unit/test_mapping_models.py
+++ b/tests/unit/test_mapping_models.py
@@ -1,0 +1,171 @@
+# tests/unit/test_mapping_models.py
+
+import unittest
+
+# Attempt to import the models. If src is not in PYTHONPATH, this might require adjustment
+# For now, assume direct import works or the execution environment handles it.
+# If issues arise, may need to adjust path or use relative imports if tests are part of the src package.
+try:
+    from src.models.sample_model import SampleModel
+    from src.models.sample_mapping_item_model import SampleMappingItemModel
+    from src.models.sample_mapping_model import SampleMappingModel
+except ImportError:
+    # This is a fallback for local testing if PYTHONPATH isn't set up in the environment
+    import sys
+    import os
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+    from src.models.sample_model import SampleModel
+    from src.models.sample_mapping_item_model import SampleMappingItemModel
+    from src.models.sample_mapping_model import SampleMappingModel
+
+
+class TestSampleModel(unittest.TestCase):
+    def test_instantiation_valid(self):
+        sample = SampleModel(file_path="test.wav", root_note=60)
+        self.assertEqual(sample.file_path, "test.wav")
+        self.assertEqual(sample.root_note, 60)
+
+    def test_instantiation_default_root_note(self):
+        sample = SampleModel(file_path="another.wav")
+        self.assertEqual(sample.file_path, "another.wav")
+        self.assertIsNone(sample.root_note)
+
+    def test_invalid_file_path(self):
+        with self.assertRaises(ValueError):
+            SampleModel(file_path="", root_note=60) # Empty file_path
+        with self.assertRaises(ValueError):
+            SampleModel(file_path=None, root_note=60) # None file_path
+
+    def test_invalid_root_note(self):
+        with self.assertRaises(ValueError):
+            SampleModel(file_path="test.wav", root_note=-1) # Below range
+        with self.assertRaises(ValueError):
+            SampleModel(file_path="test.wav", root_note=128) # Above range
+        with self.assertRaises(ValueError):
+            SampleModel(file_path="test.wav", root_note="not_an_int") # Wrong type
+
+
+class TestSampleMappingItemModel(unittest.TestCase):
+    def setUp(self):
+        self.sample = SampleModel(file_path="kick.wav", root_note=36)
+
+    def test_instantiation_valid(self):
+        item = SampleMappingItemModel(
+            sample=self.sample,
+            note_start=60, note_end=60,
+            velocity_start=80, velocity_end=100,
+            round_robin_group=1,
+            tune_cents=5.5,
+            pan=-0.5
+        )
+        self.assertIs(item.sample, self.sample)
+        self.assertEqual(item.note_start, 60)
+        self.assertEqual(item.note_end, 60)
+        self.assertEqual(item.velocity_start, 80)
+        self.assertEqual(item.velocity_end, 100)
+        self.assertEqual(item.round_robin_group, 1)
+        self.assertEqual(item.tune_cents, 5.5)
+        self.assertEqual(item.pan, -0.5)
+
+    def test_instantiation_defaults(self):
+        item = SampleMappingItemModel(sample=self.sample)
+        self.assertEqual(item.note_start, 0)
+        self.assertEqual(item.note_end, 127)
+        self.assertEqual(item.velocity_start, 0)
+        self.assertEqual(item.velocity_end, 127)
+        self.assertEqual(item.round_robin_group, 0)
+        self.assertEqual(item.tune_cents, 0.0)
+        self.assertEqual(item.pan, 0.0)
+
+    def test_invalid_sample(self):
+        with self.assertRaises(TypeError):
+            SampleMappingItemModel(sample="not_a_sample_model")
+
+    def test_invalid_note_ranges(self):
+        with self.assertRaises(ValueError): # start > end
+            SampleMappingItemModel(sample=self.sample, note_start=61, note_end=60)
+        with self.assertRaises(ValueError): # out of bounds
+            SampleMappingItemModel(sample=self.sample, note_start=-1)
+        with self.assertRaises(ValueError): # out of bounds
+            SampleMappingItemModel(sample=self.sample, note_end=128)
+
+    def test_invalid_velocity_ranges(self):
+        with self.assertRaises(ValueError): # start > end
+            SampleMappingItemModel(sample=self.sample, velocity_start=101, velocity_end=100)
+        with self.assertRaises(ValueError): # out of bounds
+            SampleMappingItemModel(sample=self.sample, velocity_start=-1)
+        with self.assertRaises(ValueError): # out of bounds
+            SampleMappingItemModel(sample=self.sample, velocity_end=128)
+
+    def test_invalid_pan_value(self):
+        with self.assertRaises(ValueError):
+            SampleMappingItemModel(sample=self.sample, pan=-1.1)
+        with self.assertRaises(ValueError):
+            SampleMappingItemModel(sample=self.sample, pan=1.1)
+
+    def test_invalid_types(self):
+        with self.assertRaises(TypeError):
+            SampleMappingItemModel(sample=self.sample, round_robin_group="abc")
+        with self.assertRaises(TypeError):
+            SampleMappingItemModel(sample=self.sample, tune_cents="abc")
+        with self.assertRaises(TypeError): # Pan type check
+            SampleMappingItemModel(sample=self.sample, pan="wrong_type")
+
+
+class TestSampleMappingModel(unittest.TestCase):
+    def setUp(self):
+        self.sample1 = SampleModel("s1.wav")
+        self.sample2 = SampleModel("s2.wav")
+        self.item1 = SampleMappingItemModel(sample=self.sample1)
+        self.item2 = SampleMappingItemModel(sample=self.sample2, note_start=60, note_end=70)
+
+    def test_instantiation(self):
+        model = SampleMappingModel()
+        self.assertEqual(len(model.mapping_items), 0)
+        self.assertEqual(len(model), 0)
+
+    def test_add_item(self):
+        model = SampleMappingModel()
+        model.add_mapping_item(self.item1)
+        self.assertEqual(len(model.mapping_items), 1)
+        self.assertIn(self.item1, model.mapping_items)
+        self.assertEqual(len(model), 1)
+
+        model.add_mapping_item(self.item2)
+        self.assertEqual(len(model.mapping_items), 2)
+        self.assertIn(self.item2, model.mapping_items)
+        self.assertEqual(len(model), 2)
+
+        # Test iteration
+        items_iterated = [item for item in model]
+        self.assertEqual(len(items_iterated), 2)
+        self.assertIn(self.item1, items_iterated)
+        self.assertIn(self.item2, items_iterated)
+
+
+    def test_add_invalid_item_type(self):
+        model = SampleMappingModel()
+        with self.assertRaises(TypeError):
+            model.add_mapping_item("not_a_mapping_item")
+
+    def test_remove_item(self):
+        model = SampleMappingModel()
+        model.add_mapping_item(self.item1)
+        model.add_mapping_item(self.item2)
+
+        model.remove_mapping_item(self.item1)
+        self.assertEqual(len(model.mapping_items), 1)
+        self.assertNotIn(self.item1, model.mapping_items)
+        self.assertIn(self.item2, model.mapping_items)
+        self.assertEqual(len(model), 1)
+
+    def test_remove_nonexistent_item(self):
+        model = SampleMappingModel()
+        model.add_mapping_item(self.item1)
+        non_existent_item = SampleMappingItemModel(SampleModel("non_existent.wav"))
+        with self.assertRaises(ValueError):
+            model.remove_mapping_item(non_existent_item)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Defines three new data models in src/models:
- SampleModel: Represents an individual audio sample file with attributes for file_path and an optional root_note.
- SampleMappingItemModel: Represents a single mapping rule, linking a SampleModel to MIDI note/velocity ranges, round-robin group, tune, and pan. Includes validation for all parameters.
- SampleMappingModel: Acts as a container for a list of SampleMappingItemModel instances, representing the complete mapping for an instrument.

All models include basic __init__ and __repr__ methods. The models are exposed via src/models/__init__.py.

Basic unit tests have been added in tests/unit/test_mapping_models.py, covering instantiation, default values, and validation logic. A minor validation bug for the 'pan' attribute in SampleMappingItemModel was fixed during testing.