### PR TITLE
Integrate and display imported audio metadata

### DIFF
--- a/src/core/project.py
+++ b/src/core/project.py
@@ -206,10 +206,19 @@ class Project:
                     exc_info=True,
                 )
 
+            filesize: int | None = None
+            try:
+                filesize = os.path.getsize(file_path)
+                logger.info(f"Retrieved file size for {file_path}: {filesize} bytes")
+            except OSError as e:
+                logger.error(f"Could not get file size for {file_path}: {e}. Recording will be added without filesize.", exc_info=True)
+
+
             new_recording: RecordingModel = RecordingModel(
                 project_id=self.project_id,
                 name=name,
                 file_path=file_path,
+                filesize=filesize,
                 duration_seconds=duration_seconds,
                 samplerate=samplerate,
                 channels=channels,

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -56,6 +56,7 @@ class Recording(Base):
     project_id: Mapped[int] = mapped_column(Integer, ForeignKey("projects.id"), nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
     file_path: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    filesize: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     duration_seconds: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     samplerate: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     channels: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -11,7 +11,7 @@
         <h1>Orchestrator Dashboard</h1>
         <nav>
             <ul>
-                <li><a href="{{ url_for('ui_bp.dashboard') }}">Dashboard</a></li>
+                <li>{% if project and project.id %}<a href="{{ url_for('ui_bp.dashboard', project_id=project.id) }}">Project Dashboard</a>{% else %}<a href="{{ url_for('ui_bp.index') }}">Home</a>{% endif %}</li>
                 <li><a href="{{ url_for('ui_bp.create_project_form') }}">Create New Project</a></li>
                 <!-- Add more links here as new pages are created -->
             </ul>

--- a/src/templates/ui/dashboard.html
+++ b/src/templates/ui/dashboard.html
@@ -1,9 +1,38 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard - Orchestrator UI{% endblock %}
+{% block title %}Dashboard - {{ project.name if project else 'Orchestrator UI' }}{% endblock %}
 
 {% block content %}
-<h2>Dashboard</h2>
-<p>Welcome to the orchestrator dashboard. This page will provide an overview of your sampling projects and their statuses.</p>
-<p><em>(Content to be added in future tasks)</em></p>
+<h1>Project Dashboard: {{ project.name if project else "Unknown Project" }}</h1>
+
+<p>This page provides an overview of the project, including its imported audio files and their metadata.</p>
+
+{% if recordings %}
+    <h2>Imported Audio Files</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Filename</th>
+                <th>Filesize (bytes)</th>
+                <th>Duration (s)</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for recording in recordings %}
+            <tr>
+                <td>{{ recording.name }}</td>
+                <td>{{ recording.filesize if recording.filesize is not none else 'N/A' }}</td>
+                <td>{{ recording.duration_seconds if recording.duration_seconds is not none else 'N/A' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <p>No audio files have been imported for this project yet.</p>
+{% endif %}
+
+<hr>
+<p><a href="{{ url_for('ui_bp.import_project_audio_ui', project_id=project.id) }}" class="btn btn-primary">Import New Audio File</a></p>
+<p><a href="{{ url_for('ui_bp.index') }}" class="btn btn-secondary">Back to Project List (Placeholder)</a></p>
+
 {% endblock %}

--- a/src/templates/ui/error.html
+++ b/src/templates/ui/error.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block title %}Error{% if error and error.code %} - {{ error.code }}{% endif %}{% endblock %}
+
+{% block content %}
+  <h2>Error {% if error and error.code %}{{ error.code }}{% else %}Encountered{% endif %}</h2>
+  <p>{{ error.description if error and error.description else 'An unexpected error occurred.' }}</p>
+  <p><a href="{{ url_for('ui_bp.index') }}">Go to Homepage</a></p>
+{% endblock %}

--- a/src/ui/routes.py
+++ b/src/ui/routes.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, render_template, abort
-from src.database.models import Project as ProjectModel
+from src.database.models import Project as ProjectModel, Recording as RecordingModel
 from src.database.utils import get_db
 
 # Define the blueprint for UI routes
@@ -12,22 +12,41 @@ ui_bp = Blueprint(
 )
 
 
-@ui_bp.route("/dashboard")
-def dashboard() -> str:
-    """Renders the main application dashboard page.
+@ui_bp.route("/projects/<int:project_id>/dashboard")
+def dashboard(project_id: int) -> str:
+    """Renders the main application dashboard page for a specific project.
 
     This route serves the primary user interface page, typically displaying
     an overview of projects, activities, or other key information.
     It utilizes the "dashboard.html" template.
 
     Args:
-        None.
+        project_id (int): The ID of the project to display the dashboard for.
 
     Returns:
         str: The rendered HTML content of the dashboard page. The page title
-             is set to "Dashboard".
+             is set to "Dashboard - {project.name}".
     """
-    return render_template("dashboard.html", title="Dashboard")
+    db_session_generator = get_db()
+    db = next(db_session_generator)
+    try:
+        project = db.query(ProjectModel).filter(ProjectModel.id == project_id).first()
+        if not project:
+            abort(404, description=f"Project with ID {project_id} not found.")
+
+        recordings = db.query(RecordingModel).filter(RecordingModel.project_id == project_id).all()
+
+        return render_template(
+            "dashboard.html",
+            title=f"Dashboard - {project.name}",
+            project=project,
+            recordings=recordings,
+        )
+    finally:
+        try:
+            next(db_session_generator)  # Ensure the finally block in get_db is executed
+        except StopIteration:
+            pass
 
 
 # Optional: Add a root route for the UI blueprint if desired,
@@ -145,16 +164,23 @@ def import_project_audio_ui(project_id: int) -> str:
     Returns:
         str: Rendered HTML page for audio import.
     """
-    db = get_db()
+    db_session_generator = get_db()
+    db = next(db_session_generator)
     project = db.query(ProjectModel).filter(ProjectModel.id == project_id).first()
 
-    if not project:
-        abort(404, description=f"Project with ID {project_id} not found.")
+    try:
+        if not project:
+            abort(404, description=f"Project with ID {project_id} not found.")
 
-    return render_template(
-        "ui/import_audio.html",
-        project_id=project.id,
-        project_name=project.name,
-        error=None,  # Initially no error
-        success_message=None,  # Initially no success message
-    )
+        return render_template(
+            "ui/import_audio.html", # This was "ui/import_audio.html" but should be "import_audio.html" given the template folder structure. Correcting this is out of scope.
+            project_id=project.id,
+            project_name=project.name,
+            error=None,  # Initially no error
+            success_message=None,  # Initially no success message
+        )
+    finally:
+        try:
+            next(db_session_generator) # Ensure the finally block in get_db is executed
+        except StopIteration:
+            pass

--- a/src/ui/routes.py
+++ b/src/ui/routes.py
@@ -213,3 +213,17 @@ def handle_ui_exception(e: HTTPException):
     # or an htmx request that doesn't set Accept: text/html),
     # return the default response from the exception (often JSON or plain text).
     return response
+
+
+@ui_bp.errorhandler(404)
+def handle_ui_404_error(e):
+    """Return a custom HTML page for 404 Not Found errors on the UI blueprint.
+    Ensures that users always see a user-friendly HTML page for 404s
+    originating from UI routes. The exception 'e' (a NotFound instance)
+    contains 'code' and 'description' attributes that are passed to the
+    error template.
+    """
+    # Note: e.code will be 404.
+    # e.description will be the message from abort(404, description="...")
+    # or a default "Not Found" message if no description was provided.
+    return render_template("error.html", error=e), 404

--- a/src/ui/routes.py
+++ b/src/ui/routes.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, render_template, abort
+from flask import Blueprint, render_template, abort, request
+from werkzeug.exceptions import HTTPException
 from src.database.models import Project as ProjectModel, Recording as RecordingModel
 from src.database.utils import get_db
 
@@ -173,7 +174,7 @@ def import_project_audio_ui(project_id: int) -> str:
             abort(404, description=f"Project with ID {project_id} not found.")
 
         return render_template(
-            "ui/import_audio.html", # This was "ui/import_audio.html" but should be "import_audio.html" given the template folder structure. Correcting this is out of scope.
+            "import_audio.html", # Corrected path based on template folder structure
             project_id=project.id,
             project_name=project.name,
             error=None,  # Initially no error
@@ -184,3 +185,31 @@ def import_project_audio_ui(project_id: int) -> str:
             next(db_session_generator) # Ensure the finally block in get_db is executed
         except StopIteration:
             pass
+
+
+# --- UI Blueprint Error Handler ---
+@ui_bp.errorhandler(HTTPException)
+def handle_ui_exception(e: HTTPException):
+    """Return HTML for HTTP errors on the UI blueprint routes.
+    This ensures that if abort() is called or an exception derived from
+    HTTPException occurs during the handling of a UI route, the user
+    is shown a user-friendly HTML error page instead of a default
+    JSON or plain text error.
+    """
+    # Get the standard response object for the exception
+    response = e.get_response()
+
+    # Check if the client prefers HTML content.
+    # The ui_bp routes are primarily for user-facing HTML, so we prioritize HTML error pages.
+    # This condition can be adjusted if some UI routes might be called by clients
+    # that don't prefer HTML (e.g., htmx requests not specifically asking for HTML snippets).
+    if "text/html" in request.accept_mimetypes:
+        # If HTML is preferred, render the custom error template.
+        # The 'error' object (the exception 'e') is passed to the template,
+        # which can then access 'e.code' and 'e.description'.
+        return render_template("error.html", error=e), e.code
+
+    # If the client does not prefer HTML (e.g., an API client mistakenly hitting a UI route,
+    # or an htmx request that doesn't set Accept: text/html),
+    # return the default response from the exception (often JSON or plain text).
+    return response

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -124,12 +124,13 @@ class TestProject(unittest.TestCase):
         # self.mock_db_session.close.assert_called_once() # If applicable
 
     @patch("src.core.project.os.path.exists", return_value=True)
+    @patch("src.core.project.os.path.getsize") # Added mock for getsize
     @patch("src.core.project.librosa.load")
     @patch("src.core.project.librosa.get_duration")
     # Patched RecordingModel will be handled by the side_effect setup
     @patch("src.core.project.get_db")
     def test_add_recording_successful_no_session_provided(
-        self, mock_get_db_rec, mock_get_duration, mock_librosa_load, mock_os_exists
+        self, mock_get_db_rec, mock_get_duration, mock_librosa_load, mock_os_path_getsize, mock_os_exists
     ):
         # Setup RecordingModel mock to return instances with attributes from kwargs
         def recording_model_factory(**kwargs):
@@ -155,6 +156,9 @@ class TestProject(unittest.TestCase):
             mock_get_db_rec.reset_mock()
             mock_get_db_rec.return_value = iter([self.mock_db_session])
 
+            # Configure mock for os.path.getsize BEFORE the call
+            mock_os_path_getsize.return_value = 12345 # Example file size in bytes
+
             dummy_audio_data = np.array([0.1, 0.2, 0.1])  # Mono
             sample_rate = 44100
             duration = 1.5
@@ -169,20 +173,41 @@ class TestProject(unittest.TestCase):
             )
 
             mock_os_exists.assert_called_once_with(file_path)
+            mock_os_path_getsize.assert_called_once_with(file_path) # Check getsize was called
             mock_librosa_load.assert_called_once_with(file_path, sr=None, mono=False)
             mock_get_duration.assert_called_once_with(y=dummy_audio_data, sr=sample_rate)
 
             self.mock_db_session.add.assert_called_once()
             added_object = self.mock_db_session.add.call_args[0][0]
 
-            self.assertIs(added_object, new_recording_model_instance)
-            self.assertEqual(added_object.project_id, self.project_id)
-            self.assertEqual(added_object.name, recording_name)
-            self.assertEqual(added_object.file_path, file_path)
-            self.assertEqual(added_object.duration_seconds, duration)
-            self.assertEqual(added_object.samplerate, sample_rate)
-            self.assertEqual(added_object.channels, 1)
-            self.assertEqual(added_object.status, "pending")
+            self.assertIs(added_object, new_recording_model_instance) # new_recording_model_instance is the return of project.add_recording
+            # The actual RecordingModel instance created inside add_recording is what's passed to db_session.add
+            # and its attributes are set based on the factory.
+            # So, we check the arguments passed to the factory.
+
+            # Check arguments passed to PatchedRecordingModel constructor
+            PatchedRecordingModel.assert_called_once_with(
+                project_id=self.project_id,
+                name=recording_name,
+                file_path=file_path,
+                filesize=12345, # Expected filesize
+                duration_seconds=duration,
+                samplerate=sample_rate,
+                channels=1, # Based on dummy_audio_data shape
+                status="pending",
+            )
+
+            # new_recording_model_instance is the object returned by project.add_recording,
+            # which IS the instance created by PatchedRecordingModel factory.
+            # So we can assert its attributes directly.
+            self.assertEqual(new_recording_model_instance.project_id, self.project_id)
+            self.assertEqual(new_recording_model_instance.name, recording_name)
+            self.assertEqual(new_recording_model_instance.file_path, file_path)
+            self.assertEqual(new_recording_model_instance.filesize, 12345) # Assert filesize on the returned instance
+            self.assertEqual(new_recording_model_instance.duration_seconds, duration)
+            self.assertEqual(new_recording_model_instance.samplerate, sample_rate)
+            self.assertEqual(new_recording_model_instance.channels, 1)
+            self.assertEqual(new_recording_model_instance.status, "pending")
 
             self.mock_db_session.commit.assert_called_once()
             self.mock_db_session.refresh.assert_called_once_with(added_object)
@@ -192,11 +217,12 @@ class TestProject(unittest.TestCase):
             )  # After reset_mock, add_recording calls it once.
 
     @patch("src.core.project.os.path.exists", return_value=True)
+    @patch("src.core.project.os.path.getsize") # Added mock for getsize
     @patch("src.core.project.librosa.load")
     @patch("src.core.project.librosa.get_duration")
     # Patched RecordingModel will be handled by the side_effect setup
     def test_add_recording_successful_session_provided(
-        self, mock_get_duration, mock_librosa_load, mock_os_exists
+        self, mock_get_duration, mock_librosa_load, mock_os_path_getsize, mock_os_exists
     ):
         def recording_model_factory(**kwargs):
             instance = MagicMock(name="RecordingModelInstance_Mock")
@@ -213,6 +239,9 @@ class TestProject(unittest.TestCase):
             project = Project(project_id=self.project_id, db_session=self.mock_db_session)
             self.mock_db_session.reset_mock()
 
+            # Configure mock for os.path.getsize BEFORE the call
+            mock_os_path_getsize.return_value = 54321 # Different filesize for this test
+
             stereo_audio_data = np.array([[0.1, 0.2], [0.3, 0.4]])
             sample_rate = 22050
             duration = 0.5
@@ -226,10 +255,30 @@ class TestProject(unittest.TestCase):
                 file_path=file_path, name=recording_name
             )
 
+            mock_os_path_getsize.return_value = 54321 # Different filesize for this test
+
+            new_recording_model_instance = project.add_recording(
+                file_path=file_path, name=recording_name
+            )
+
+            mock_os_path_getsize.assert_called_once_with(file_path)
+
             self.mock_db_session.add.assert_called_once()
-            added_object = self.mock_db_session.add.call_args[0][0]
-            self.assertIs(added_object, new_recording_model_instance)
-            self.assertEqual(added_object.channels, 2)
+            # Check arguments passed to PatchedRecordingModel constructor
+            PatchedRecordingModel.assert_called_once_with(
+                project_id=self.project_id,
+                name=recording_name,
+                file_path=file_path,
+                filesize=54321, # Expected filesize
+                duration_seconds=duration,
+                samplerate=sample_rate,
+                channels=2, # Based on stereo_audio_data shape
+                status="pending",
+            )
+
+            # Assert attributes on the returned instance
+            self.assertEqual(new_recording_model_instance.filesize, 54321)
+            self.assertEqual(new_recording_model_instance.channels, 2) # Existing check
             self.mock_db_session.commit.assert_called_once()
 
     @patch("src.core.project.os.path.exists", return_value=False)

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -255,12 +255,6 @@ class TestProject(unittest.TestCase):
                 file_path=file_path, name=recording_name
             )
 
-            mock_os_path_getsize.return_value = 54321 # Different filesize for this test
-
-            new_recording_model_instance = project.add_recording(
-                file_path=file_path, name=recording_name
-            )
-
             mock_os_path_getsize.assert_called_once_with(file_path)
 
             self.mock_db_session.add.assert_called_once()

--- a/tests/database/test_models.py
+++ b/tests/database/test_models.py
@@ -158,6 +158,47 @@ def test_create_recording(db_session: SQLAlchemySession) -> None:
         assert recording.project.name == "Project For Recordings"
 
 
+def test_create_recording_with_filesize(db_session: SQLAlchemySession) -> None:
+    """Test creating a Recording model instance with a filesize.
+
+    Args:
+        db_session: The SQLAlchemy session fixture.
+    """
+    project = Project(name="Project For Recording With Filesize")
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+
+    recording = Recording(
+        project_id=project.id,  # type: ignore
+        name="Test Recording With Filesize",
+        file_path="/path/to/recording_with_filesize.wav",
+        filesize=1024768,  # Example filesize in bytes
+        duration_seconds=180.2,
+        samplerate=48000,
+        channels=1,
+        status="processed",
+    )
+    db_session.add(recording)
+    db_session.commit()
+    db_session.refresh(recording)
+
+    assert recording.id is not None
+    assert recording.project_id == project.id
+    assert recording.name == "Test Recording With Filesize"
+    assert recording.file_path == "/path/to/recording_with_filesize.wav"
+    assert recording.filesize == 1024768
+    assert recording.status == "processed"
+
+    retrieved_recording: Recording | None = (
+        db_session.query(Recording).filter(Recording.id == recording.id).first()
+    )
+    assert retrieved_recording is not None
+    if retrieved_recording:  # For type checker
+        assert retrieved_recording.filesize == 1024768
+        assert retrieved_recording.name == "Test Recording With Filesize"
+
+
 def test_update_recording_status(db_session: SQLAlchemySession) -> None:
     """Test updating the status of a Recording model instance.
 

--- a/tests/ui/test_ui_routes.py
+++ b/tests/ui/test_ui_routes.py
@@ -82,7 +82,10 @@ def test_dashboard_project_not_exists(client: FlaskClient):
     """Test dashboard returns 404 for a non-existent project."""
     response = client.get("/ui/projects/99999/dashboard")
     assert response.status_code == 404
+    # Check for content from the error.html template
+    assert b"Error 404" in response.data
     assert b"Project with ID 99999 not found" in response.data
+    assert b"Go to Homepage" in response.data # Link from error.html
 
 
 def test_dashboard_project_exists_no_recordings(client: FlaskClient, db_session: SQLAlchemySession):

--- a/tests/ui/test_ui_routes.py
+++ b/tests/ui/test_ui_routes.py
@@ -229,7 +229,7 @@ def test_dashboard_project_exists_with_recordings(client: FlaskClient, db_sessio
 # to ensure it's rendered safely by Jinja2 (which it does by default).
 def test_dashboard_project_name_with_special_chars(client: FlaskClient, db_session: SQLAlchemySession):
     """Test project name with special HTML characters is displayed correctly (escaped)."""
-    special_name = "Project with <script>alert('XSS')</script> & \"quotes\""
+    special_name = "Project with <script>alert('XSS')</script> & \"quotes\"" # Restored original
     project = ProjectModel(name=special_name)
     db_session.add(project)
     db_session.commit()
@@ -239,14 +239,36 @@ def test_dashboard_project_name_with_special_chars(client: FlaskClient, db_sessi
     assert response.status_code == 200
     response_data = response.data.decode("utf-8")
 
-    # Jinja2 auto-escapes by default, so these should be escaped in the HTML
-    assert "Project Dashboard: Project with &lt;script&gt;alert('XSS')&lt;/script&gt; &amp; &quot;quotes&quot;" in response_data
-    # Also check the title
-    assert "<title>Dashboard - Project with &lt;script&gt;alert('XSS')&lt;/script&gt; &amp; &quot;quotes&quot;</title>" in response_data
+    # Based on DEBUG_OUTPUT:
+    # & -> &amp;
+    # < -> &lt;
+    # > -> &gt;
+    # " -> &#34;  (Note: not &quot;)
+    # ' -> &#39;
+    escaped_name = "Project with &lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt; &amp; &#34;quotes&#34;"
 
-    # Ensure the raw special characters are NOT present (which would indicate lack of escaping)
+    expected_h1_content = f"<h1>Project Dashboard: {escaped_name}</h1>"
+    expected_title_content = f"<title>Dashboard - {escaped_name}</title>"
+
+    # Normalize whitespace for robust comparison
+    normalized_response_data = ' '.join(response_data.split())
+
+    # Check for the core escaped string content first
+    core_escaped_name_part = escaped_name
+    assert core_escaped_name_part in normalized_response_data
+
+    # If the core part is found, then check the full H1 and title structure
+    normalized_expected_h1 = ' '.join(expected_h1_content.split())
+    normalized_expected_title = ' '.join(expected_title_content.split())
+
+    assert normalized_expected_h1 in normalized_response_data
+    assert normalized_expected_title in normalized_response_data
+
+    # Ensure the raw special_name string is NOT present in the response_data
+    assert special_name not in response_data
+    # Also ensure common problematic substrings from the original raw string are not present if they imply lack of escaping
     assert "<script>alert('XSS')</script>" not in response_data
-    assert " \"quotes\"" not in response_data # Check raw quotes if they were part of an attribute value without proper quoting
+    assert " & \"quotes\"" not in response_data
 
 # Test project name with non-ASCII characters (Unicode)
 def test_dashboard_project_name_with_unicode_chars(client: FlaskClient, db_session: SQLAlchemySession):

--- a/tests/ui/test_ui_routes.py
+++ b/tests/ui/test_ui_routes.py
@@ -1,0 +1,262 @@
+import pytest
+import json
+from flask import Flask
+from flask.testing import FlaskClient
+from sqlalchemy.orm import Session as SQLAlchemySession
+from sqlalchemy.engine import Engine
+
+from src.app import create_app
+from src.database.utils import (
+    init_db as initialize_db_utils,
+    get_engine,
+    get_session_local,
+)
+from src.database.models import Base, Project as ProjectModel, Recording as RecordingModel
+
+from typing import Generator
+
+
+# --- Test Fixtures ---
+@pytest.fixture(scope="module")
+def app() -> Generator[Flask, None, None]:
+    """Create and configure a new app instance for each test module."""
+    flask_app: Flask = create_app()
+    flask_app.config.update(
+        {
+            "TESTING": True,
+            "DATABASE_URL": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,  # Disable CSRF for simpler form tests if any
+        }
+    )
+
+    engine: Engine = get_engine(flask_app.config["DATABASE_URL"])
+    flask_app.config["TEST_ENGINE_INSTANCE"] = engine
+
+    with flask_app.app_context():
+        initialize_db_utils(engine_instance=engine)
+
+    yield flask_app
+
+
+@pytest.fixture
+def client(app: Flask) -> FlaskClient:
+    """A test client for the app."""
+    return app.test_client()
+
+
+@pytest.fixture(scope="function") # Changed to function scope for UI tests if DB state needs to be very specific per test
+def db_session(app: Flask) -> Generator[SQLAlchemySession, None, None]:
+    """Provides a SQLAlchemy session with access to the test database.
+    Ensures the session is closed after the test.
+    """
+    engine: Engine = app.config["TEST_ENGINE_INSTANCE"]
+    SessionLocal_test = get_session_local(engine_instance=engine)
+    session: SQLAlchemySession = SessionLocal_test()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture(autouse=True)
+def manage_database_tables(app: Flask, db_session: SQLAlchemySession) -> Generator[None, None, None]:
+    """Ensure each test has a clean database state (empty tables)."""
+    # The app context is already active from the app fixture for initializing the schema
+    # For clearing tables, we use the db_session fixture which provides a session
+    # from the app's test engine.
+
+    # Clear data from all tables before each test
+    for table in reversed(Base.metadata.sorted_tables):
+        db_session.execute(table.delete())
+    db_session.commit()
+
+    yield
+
+    # No explicit teardown needed here as db_session fixture handles session closing
+    # and in-memory DB data is lost when connection closes.
+
+
+# --- UI Route Tests ---
+
+def test_dashboard_project_not_exists(client: FlaskClient):
+    """Test dashboard returns 404 for a non-existent project."""
+    response = client.get("/ui/projects/99999/dashboard")
+    assert response.status_code == 404
+    assert b"Project with ID 99999 not found" in response.data
+
+
+def test_dashboard_project_exists_no_recordings(client: FlaskClient, db_session: SQLAlchemySession):
+    """Test dashboard for an existing project with no recordings."""
+    # Create a project
+    project = ProjectModel(name="UI Test Project 1", description="No recordings here")
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+
+    response = client.get(f"/ui/projects/{project.id}/dashboard")
+    assert response.status_code == 200
+    response_data = response.data.decode("utf-8")
+
+    assert f"Project Dashboard: {project.name}" in response_data
+    assert "No audio files have been imported for this project yet." in response_data
+    assert "Imported Audio Files" not in response_data # Table heading should not be present
+
+
+def test_dashboard_project_exists_with_recordings(client: FlaskClient, db_session: SQLAlchemySession):
+    """Test dashboard for an existing project with recordings."""
+    # Create a project
+    project = ProjectModel(name="UI Test Project 2", description="Has recordings")
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+
+    # Create recordings for this project
+    rec1 = RecordingModel(
+        project_id=project.id,
+        name="audio_file_1.wav",
+        file_path="/path/to/audio_1.wav",
+        filesize=123456,
+        duration_seconds=10.5,
+        samplerate=44100,
+        channels=2,
+        status="processed"
+    )
+    rec2 = RecordingModel(
+        project_id=project.id,
+        name="long_audio_sample.mp3",
+        file_path="/another/path/long_audio_sample.mp3",
+        filesize=7890123,
+        duration_seconds=185.7,
+        samplerate=48000,
+        channels=1,
+        status="processed"
+    )
+    rec3 = RecordingModel( # Recording with missing filesize/duration
+        project_id=project.id,
+        name="incomplete_meta.aif",
+        file_path="/path/incomplete.aif",
+        filesize=None,
+        duration_seconds=None,
+        status="pending"
+    )
+    db_session.add_all([rec1, rec2, rec3])
+    db_session.commit()
+    db_session.refresh(rec1)
+    db_session.refresh(rec2)
+    db_session.refresh(rec3)
+
+    response = client.get(f"/ui/projects/{project.id}/dashboard")
+    assert response.status_code == 200
+    response_data = response.data.decode("utf-8")
+
+    assert f"Project Dashboard: {project.name}" in response_data
+    assert "Imported Audio Files" in response_data
+    assert "No audio files have been imported for this project yet." not in response_data
+
+    # Check for rec1 details
+    assert rec1.name in response_data
+    assert str(rec1.filesize) in response_data
+    assert str(rec1.duration_seconds) in response_data
+
+    # Check for rec2 details
+    assert rec2.name in response_data
+    assert str(rec2.filesize) in response_data
+    assert str(rec2.duration_seconds) in response_data
+
+    # Check for rec3 details (handling None)
+    assert rec3.name in response_data
+    assert "N/A" in response_data # Check for how None filesize/duration is rendered
+
+    # Check table structure (presence of <td> tags for specific data points)
+    assert f"<td>{rec1.name}</td>" in response_data
+    assert f"<td>{rec1.filesize}</td>" in response_data
+    assert f"<td>{rec1.duration_seconds}</td>" in response_data
+
+    assert f"<td>{rec3.name}</td>" in response_data
+    assert f"<td>N/A</td>" in response_data # For filesize of rec3
+    # Assuming duration for rec3 is also N/A if both are None
+    # Example: <td>N/A</td><td>N/A</td>
+
+    # Count N/A occurrences for rec3 to be more specific
+    # Each None field for rec3 (filesize, duration_seconds) should result in one "N/A"
+    # So, for rec3, we expect two "N/A"s in its row.
+    # A more robust check might parse the HTML table or count specific row content.
+    # This simple check might be fragile if "N/A" appears elsewhere for other reasons.
+    # For now, let's assume this level of checking is sufficient:
+    expected_na_for_rec3 = 0
+    if rec3.filesize is None:
+        expected_na_for_rec3 +=1
+    if rec3.duration_seconds is None:
+        expected_na_for_rec3 +=1
+
+    # This is a bit tricky with simple string contains. A more robust HTML parsing would be better.
+    # For this test, checking for one "N/A" is a basic confirmation.
+    # More specific would be: assert f"<td>{rec3.name}</td><td>N/A</td><td>N/A</td>" in response_data (if order is fixed)
+    # For now, checking "N/A" appears at least `expected_na_for_rec3` times more than other N/A's
+    # This is still not ideal. Let's keep it simple:
+    assert "<td>N/A</td>" in response_data # At least one N/A from rec3
+
+    assert "No audio files have been imported for this project yet." not in response_data
+
+# Example of how to add a project with a specific ID if needed,
+# but usually letting auto-increment is fine for these tests.
+# def test_specific_project_id_scenario(client: FlaskClient, db_session: SQLAlchemySession):
+#     project = ProjectModel(id=100, name="Fixed ID Project")
+#     db_session.add(project)
+#     db_session.commit()
+#     # ... rest of test ...
+#     response = client.get(f"/ui/projects/100/dashboard")
+#     assert response.status_code == 200
+#     assert b"Fixed ID Project" in response.data
+
+# Consider adding a test for a project that exists but has an ID of 0 if your system allows it,
+# or other edge case IDs if relevant. For typical auto-incrementing primary keys, non-positive IDs
+# shouldn't occur unless manually inserted or sequences are misconfigured.
+# For this app, project_id is int, so positive integers are expected.
+# Non-existent check (99999) covers invalid IDs well.
+# Test for project ID 0 if it's a possible valid ID:
+# def test_dashboard_project_id_zero(client: FlaskClient, db_session: SQLAlchemySession):
+#     # Setup project with ID 0 if allowed and makes sense for your DB schema
+#     # ...
+#     # response = client.get("/ui/projects/0/dashboard")
+#     # Assert accordingly
+#     pass # Placeholder if ID 0 is not a special case or not allowed.
+
+# Test with a project that has a name that might need HTML escaping (e.g., contains <, >, &)
+# to ensure it's rendered safely by Jinja2 (which it does by default).
+def test_dashboard_project_name_with_special_chars(client: FlaskClient, db_session: SQLAlchemySession):
+    """Test project name with special HTML characters is displayed correctly (escaped)."""
+    special_name = "Project with <script>alert('XSS')</script> & \"quotes\""
+    project = ProjectModel(name=special_name)
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+
+    response = client.get(f"/ui/projects/{project.id}/dashboard")
+    assert response.status_code == 200
+    response_data = response.data.decode("utf-8")
+
+    # Jinja2 auto-escapes by default, so these should be escaped in the HTML
+    assert "Project Dashboard: Project with &lt;script&gt;alert('XSS')&lt;/script&gt; &amp; &quot;quotes&quot;" in response_data
+    # Also check the title
+    assert "<title>Dashboard - Project with &lt;script&gt;alert('XSS')&lt;/script&gt; &amp; &quot;quotes&quot;</title>" in response_data
+
+    # Ensure the raw special characters are NOT present (which would indicate lack of escaping)
+    assert "<script>alert('XSS')</script>" not in response_data
+    assert " \"quotes\"" not in response_data # Check raw quotes if they were part of an attribute value without proper quoting
+
+# Test project name with non-ASCII characters (Unicode)
+def test_dashboard_project_name_with_unicode_chars(client: FlaskClient, db_session: SQLAlchemySession):
+    """Test project name with Unicode characters is displayed correctly."""
+    unicode_name = "Projet de Test Français (éàçüö)"
+    project = ProjectModel(name=unicode_name)
+    db_session.add(project)
+    db_session.commit()
+    db_session.refresh(project)
+
+    response = client.get(f"/ui/projects/{project.id}/dashboard")
+    assert response.status_code == 200
+    response_data = response.data.decode("utf-8") # Ensure decoding as UTF-8
+
+    assert f"Project Dashboard: {unicode_name}" in response_data
+    assert f"<title>Dashboard - {unicode_name}</title>" in response_data


### PR DESCRIPTION
This commit introduces the functionality to store and display metadata for imported audio files.

Key changes:
- Extended `RecordingModel` to include a `filesize` field.
- Updated the audio upload logic (`Project.add_recording`) to calculate and store the `filesize` and ensure `duration_seconds` are populated for new recordings.
- Modified the dashboard UI route (`/ui/projects/<int:project_id>/dashboard`) to be project-specific. It now fetches the project's details and its associated audio recordings.
- Updated the `dashboard.html` template to display the project name and a table listing imported audio files with their filename, filesize, and duration. Handles cases where metadata might be missing.
- Added comprehensive unit and integration tests for the model changes, core logic, and the new UI functionality, including checks for data rendering and error handling.